### PR TITLE
Fix transcript fetch failures and update panel copy to Moyas branding

### DIFF
--- a/config.json
+++ b/config.json
@@ -53,7 +53,7 @@
     "vergoedingen": {
       "channelId": "1212538292344717332",
       "title": "Vergoedingen-aanvragen",
-      "description": "(VUL HIER JE TEKST IN)",
+      "description": "Vergoedingen\n🌟 Welkom bij Moyas Roleplay! 🌟\n\nWe zijn blij je in onze stad te hebben! Om je ervaring nog beter te maken en je te helpen je weg te vinden, bieden we drie fantastische vergoedingen aan. Of je nu nieuw bent in de stad, je vrienden meebrengt, of gewoon tijd investeert in onze gemeenschap, we hebben iets speciaals voor jou. Hier is alles wat je moet weten:\n\n🏠 Verhuisvergoeding\nHeb je meer dan 24 uur in onze stad doorgebracht? Dan kom je in aanmerking voor een verhuisvergoeding van €150.000! Deze financiële boost helpt je om gemakkelijker aan zaken te komen en je leven in de stad te starten. Om deze vergoeding aan te vragen, dien je een ticket in te dienen op onze Discord.\n\n👫 Vriendvergoeding\nBreng je vrienden mee naar Moyas Roleplay en profiteer! Voor elke vriend die je introduceert en die meer dan 24 uur speeltijd bereikt, ontvang je €100.000. Dit geldt voor maximaal 3 vrienden, wat betekent dat je tot €300.000 kunt verdienen! Zorg ervoor dat je een ticket aanmaakt en ons laat weten wie je hebt uitgenodigd.\n\n⏳ Spelersduurvergoeding\nToegewijd aan onze gemeenschap? Speel meer dan 48 uur en je bent in aanmerking voor een royale beloning van €250.000. Het is onze manier om dankjewel te zeggen voor je tijd en betrokkenheid. Vergeet niet je ticket in te dienen om je vergoeding te claimen!\n\n📝 Hoe aan te vragen?\nOm een van deze vergoedingen aan te vragen, maak je eenvoudigweg een ticket aan op onze Discord onder de sectie 'Vergoeding Aanvragen'. Zorg ervoor dat je duidelijk aangeeft welke vergoeding je aanvraagt en voldoe aan alle vereisten.\n\nWe kijken ernaar uit je te zien groeien en bloeien in Moyas Roleplay. Als je vragen hebt, aarzel dan niet om contact op te nemen met ons supportteam via Discord.\n\nLaten we samen prachtige verhalen creëren! 🎉",
       "buttons": [
         {
           "label": "Ticket openen",
@@ -65,7 +65,7 @@
     "support": {
       "channelId": "1193935336422776872",
       "title": "Support",
-      "description": "(VUL HIER JE TEKST IN)",
+      "description": "Support\n🌟 Welkom Inwoners van Moyas Roleplay 🌟\n\nWij zijn hier om jullie een geweldige spelervaring te bieden. Hieronder vind je uitleg over de verschillende soorten tickets die je kunt aanvragen.\n\n1️⃣ Support Ticket\nHeb je technische problemen, vragen over de serverregels, of hulp nodig met accountgerelateerde zaken? Dan is het Support Ticket jouw go-to. Klik op Support Ticket en leg je situatie uit. Een van onze supportteamleden zal zo snel mogelijk reageren om je te helpen.\n\n2️⃣ Scenario Ticket\nIs er iets misgegaan in een recent scenario waarbij je betrokken was? Wil je een situatie bespreken of aanpakken waarbij je denkt dat de dingen niet volgens de regels of verwachtingen zijn verlopen? Het Scenario Ticket is speciaal hiervoor bedoeld. Gebruik dit ticket om een incident of situatie te melden waar je bezorgd over bent. Beschrijf wat er gebeurd is, voeg indien mogelijk bewijsmateriaal toe, en vermeld de betrokken partijen. Een lid van ons staffteam zal het incident bekijken en, indien nodig, een gesprek organiseren met alle betrokken partijen om tot een oplossing te komen.\n\nOnthoud: We streven naar een respectvolle en ondersteunende community. Wees geduldig na het indienen van je ticket; we zullen zo snel mogelijk bij je terugkomen.\n\nBedankt voor het spelen op Moyas Roleplay! Laten we samen fantastische verhalen creëren! 🚀",
       "buttons": [
         {
           "label": "Support Ticket",
@@ -82,7 +82,7 @@
     "unban": {
       "channelId": "1193934940165902396",
       "title": "Unban",
-      "description": "(VUL HIER JE TEKST IN)",
+      "description": "Unban ticket\n1️⃣ Unban Ticket\nHeb je een ban gekregen en wil je een herziening aanvragen? Het Unban Ticket geeft je de mogelijkheid om je zaak opnieuw te laten beoordelen. We begrijpen dat mensen fouten kunnen maken of dat er misverstanden kunnen ontstaan. Als je denkt dat je ban onterecht of te streng was, kun je een Unban Ticket openen om je situatie uit te leggen.\n\nIn je Unban Ticket, geef alsjeblieft duidelijk en respectvol de volgende informatie:\n\nJe gebruikersnaam en de datum van de ban.\nEen beknopte beschrijving van de gebeurtenissen die tot de ban hebben geleid.\nDe reden waarom je denkt dat de ban onterecht of te streng is.\nEventuele bewijzen of aanvullende opmerkingen die kunnen helpen bij de herziening van je zaak.",
       "buttons": [
         {
           "label": "Ticket openen",
@@ -94,7 +94,7 @@
     "overheid": {
       "channelId": "1193935078275944538",
       "title": "Overheid",
-      "description": "(VUL HIER JE TEKST IN)",
+      "description": "Moyas Roleplay Overheid\n🚨 Solliciteren naar Overheidsbanen 🚨\n\nWil je een actieve rol spelen in onze community en deelnemen aan spannende, realistische roleplay? Overweeg dan om te solliciteren voor een van onze overheidsbanen! Momenteel zijn we op zoek naar actieve spelers voor de volgende rollen:\n\n1️⃣ Politie: Handhavers van de wet en orde. Ben je klaar om de veiligheid van onze stad te waarborgen?\n\n2️⃣ Ambulance: Levensredders in noodsituaties. Heb jij wat nodig is om levens te redden en eerste hulp te verlenen?\n\n3️⃣ ANWB: Helden van de weg, altijd klaar om hulp te bieden bij pech of ongevallen. Is technische kennis jouw specialiteit?\n\n4️⃣ Taxi: Het hart van het stadsvervoer. Kun jij mensen op tijd en veilig naar hun bestemming brengen?\n\nWat Zoeken We?\n\nMinimaal 15 jaar.\nVermogen om realistische en boeiende roleplay te creëren.\nGoede communicatievaardigheden en teamwerk.\nBegrip van de serverregels en -protocollen.\n\nLet op: De Koninklijke Marechaussee  is momenteel niet open voor sollicitaties.\n\nWord deel van ons team en draag bij aan een unieke en levendige roleplay ervaring op Moyas Roleplay! Wij kijken uit naar je sollicitatie! 🌟\n\nBedankt voor het spelen op Moyas Roleplay! Laten we samen fantastische verhalen creëren! 🚀",
       "buttons": [
         {
           "label": "Ticket openen",


### PR DESCRIPTION
### Motivation

- The transcript builder could return `Geen transcript beschikbaar (fetch error).` when trying to fetch more messages than the API supports or when an intermediate fetch failed, and several panel descriptions were left as placeholders and referenced the old "Schilderswijk" branding.

### Description

- Reworked `buildTranscript` in `handlers/ticketHandler.js` to paginate message fetches in batches of up to 100 and to aggregate already-fetched messages so a later fetch failure does not discard previous results.
- Added a `maxMessages` cap and `before`-based pagination to avoid invalid large `limit` calls and to preserve ordering when concatenating pages in the transcript output.
- Replaced placeholder texts in `config.json` with the provided Dutch content for the `vergoedingen`, `support`, `unban`, and `overheid` panels and updated branding references from `Schilderswijk` to `Moyas`.

### Testing

- Ran syntax/type checks with `node --check handlers/ticketHandler.js`, `node --check index.js`, `node --check panels/panelHandler.js`, and `node --check handlers/commandHandler.js`, all of which completed without errors.
- Verified there are no remaining occurrences of the old branding by running a search for `Schilderswijk` in relevant files, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e48f70ec483328d9c1f5dfb1f1e68)