### PR TITLE
Fix duplicate startup messages and restore ticket actions after bot restart

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ client.once("clientReady", async () => {
   // Register slash commands (guild-level for fast availability)
   await commandHandler.registerGuildCommands(client, config);
 
+  // Herstel open ticket knoppen/log berichten na restart
+  await ticketHandler.syncOpenTickets(client, config);
+
   // Upsert permanent wachtkamer bericht
   await panelHandler.upsertPermanentMessage(client, config);
 });


### PR DESCRIPTION
### Motivation
- Prevent duplicate panel/permanent messages being posted on bot restart when stored `messageId`s are stale or missing.
- Ensure ticket UI remains functional after a restart by restoring ticket action buttons and join-log messages.

### Description
- Update `panels/panelHandler.js` to detect and reuse recent matching bot messages by title and button `customId`s using `sameButtons` and `findExistingPanelMessage`, and update stored `messageId` instead of always sending a new message.
- Add fallback logic in `upsertPermanentMessage` to find and edit an existing support/wachtkamer bot message if the saved `messageId` is unavailable.
- Add `syncOpenTickets` to `handlers/ticketHandler.js` to re-apply the `Sluit Ticket` button to each ticket's first message and re-create/update join-log messages for all open tickets on startup.
- Wire the ticket sync into startup flow in `index.js` by calling `await ticketHandler.syncOpenTickets(client, config);` after registering commands.

### Testing
- Ran static checks with `node --check index.js`, `node --check panels/panelHandler.js`, and `node --check handlers/ticketHandler.js`, all succeeded. 
- Verified diffs and updated files: `index.js`, `panels/panelHandler.js`, and `handlers/ticketHandler.js` (local validation only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e52fac06083328d8d07bf382ccf6a)