### PR TITLE
Harden MySQL bootstrap and clarify manual DB setup

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -53,7 +53,7 @@ Als je deze flags aanzet, zorg dan dat dezelfde intents ook in de Discord Develo
   - transcript wordt naar ticket-opener (DM) gestuurd
   - transcript wordt in transcript-log kanaal geplaatst
   - close-log embed met metadata wordt verstuurd
-  - ticket wordt gearchiveerd in `storage/tickets.json`
+  - ticket wordt gearchiveerd in MySQL (fallback: `storage/tickets.json`)
 
 ### 5) Ticketbeheer en hulpmiddelen
 - Ticket hernoemen.
@@ -101,13 +101,47 @@ Als je deze flags aanzet, zorg dan dat dezelfde intents ook in de Discord Develo
 - `permanentSupportMessage`
 
 ## Data-opslag
+Standaard gebruikt de bot nu MySQL (geschikt voor XAMPP/phpMyAdmin).
+
+- Database: `bot_tickets_live` (of wat je zet in `DB_NAME`)
+- Tabel: `app_state`
+  - sleutel `tickets`: open tickets, gesloten tickets, close requests, next ticket ID
+  - sleutel `panels`: panel message IDs + permanente message IDs
+
+Je hoeft normaal **geen tabel handmatig** te maken: de bot maakt `app_state` automatisch aan bij startup.
+Als je DB `bot_tickets_live` nog niet bestaat, probeert de bot die ook automatisch aan te maken.
+
+Als MySQL niet bereikbaar is, valt de bot automatisch terug op:
 - `storage/tickets.json`
-  - open tickets
-  - gesloten tickets
-  - close request status
 - `storage/panels.json`
-  - panel message IDs
-  - permanent message IDs
+
+### Database omgeving variabelen
+Zet deze in je `.env` (of als system env vars):
+- `DB_HOST=127.0.0.1`
+- `DB_PORT=3306`
+- `DB_USER=root`
+- `DB_PASSWORD=`
+- `DB_NAME=bot_tickets_live`
+
+Optioneel:
+- `STORAGE_MODE=json` om MySQL uit te zetten en altijd JSON te gebruiken.
+
+### Handmatig aanmaken in phpMyAdmin (optioneel)
+Als je het liever zelf doet, kun je deze SQL uitvoeren:
+
+```sql
+CREATE DATABASE IF NOT EXISTS `bot_tickets_live`
+  CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+USE `bot_tickets_live`;
+
+CREATE TABLE IF NOT EXISTS `app_state` (
+  `state_key` VARCHAR(64) NOT NULL,
+  `state_value` LONGTEXT NOT NULL,
+  `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`state_key`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
 
 ## Tip
 Na het aanpassen van commandonamen of beschrijvingen: herstart de bot zodat guild slash commands opnieuw worden geregistreerd.

--- a/handlers/helpers.js
+++ b/handlers/helpers.js
@@ -1,8 +1,16 @@
 const fs = require("fs");
 const path = require("path");
+const mysql = require("mysql2/promise");
 
 const STORE_TICKETS = path.join(__dirname, "..", "storage", "tickets.json");
 const STORE_PANELS = path.join(__dirname, "..", "storage", "panels.json");
+
+const DEFAULT_TICKETS = { nextTicketId: 1000, openTickets: {}, closedTickets: {} };
+const DEFAULT_PANELS = { panels: {} };
+
+let pool;
+let databaseReady = false;
+let migrationDone = false;
 
 function loadJson(p, fallback) {
   try { return JSON.parse(fs.readFileSync(p, "utf8")); }
@@ -13,17 +21,189 @@ function saveJson(p, data) {
   fs.writeFileSync(p, JSON.stringify(data, null, 2));
 }
 
-function loadTickets() {
-  return loadJson(STORE_TICKETS, { nextTicketId: 1000, openTickets: {}, closedTickets: {} });
+function mysqlEnabled() {
+  return String(process.env.STORAGE_MODE || "mysql").toLowerCase() !== "json";
 }
-function saveTickets(data) { saveJson(STORE_TICKETS, data); }
 
-function loadPanels() { return loadJson(STORE_PANELS, { panels: {} }); }
-function savePanels(data) { saveJson(STORE_PANELS, data); }
+function dbConfig() {
+  return {
+    host: process.env.DB_HOST || "127.0.0.1",
+    port: Number(process.env.DB_PORT || 3306),
+    user: process.env.DB_USER || "root",
+    password: process.env.DB_PASSWORD || "",
+    database: process.env.DB_NAME || "bot_tickets_live"
+  };
+}
 
-function nextTicketId(store) {
-  store.nextTicketId = (store.nextTicketId || 1000) + 1;
-  return store.nextTicketId;
+async function ensureDatabase() {
+  if (!mysqlEnabled()) return false;
+  if (databaseReady && pool) return true;
+
+  const cfg = dbConfig();
+
+  try {
+    const makePool = () => mysql.createPool({
+      host: cfg.host,
+      port: cfg.port,
+      user: cfg.user,
+      password: cfg.password,
+      database: cfg.database,
+      waitForConnections: true,
+      connectionLimit: 10,
+      namedPlaceholders: true
+    });
+
+    pool = makePool();
+
+    await pool.query(`
+      CREATE TABLE IF NOT EXISTS app_state (
+        state_key VARCHAR(64) PRIMARY KEY,
+        state_value LONGTEXT NOT NULL,
+        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+    `);
+
+    databaseReady = true;
+    return true;
+  } catch (error) {
+    const missingDb = error?.code === "ER_BAD_DB_ERROR";
+
+    if (!missingDb) {
+      console.error("[storage] MySQL niet beschikbaar, fallback naar JSON:", error.message);
+      pool = null;
+      databaseReady = false;
+      return false;
+    }
+
+    try {
+      const bootstrap = await mysql.createConnection({
+        host: cfg.host,
+        port: cfg.port,
+        user: cfg.user,
+        password: cfg.password,
+        multipleStatements: true
+      });
+
+      await bootstrap.query(`CREATE DATABASE IF NOT EXISTS \`${cfg.database}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci`);
+      await bootstrap.end();
+
+      pool = mysql.createPool({
+        host: cfg.host,
+        port: cfg.port,
+        user: cfg.user,
+        password: cfg.password,
+        database: cfg.database,
+        waitForConnections: true,
+        connectionLimit: 10,
+        namedPlaceholders: true
+      });
+
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS app_state (
+          state_key VARCHAR(64) PRIMARY KEY,
+          state_value LONGTEXT NOT NULL,
+          updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+      `);
+
+      databaseReady = true;
+      return true;
+    } catch (bootstrapError) {
+      console.error("[storage] MySQL niet beschikbaar, fallback naar JSON:", bootstrapError.message);
+      pool = null;
+      databaseReady = false;
+      return false;
+    }
+  }
+}
+
+async function migrateJsonToDatabaseIfNeeded() {
+  if (!mysqlEnabled()) return;
+  if (migrationDone) return;
+
+  const ready = await ensureDatabase();
+  if (!ready) return;
+
+  const [[ticketsRow]] = await pool.query("SELECT state_key FROM app_state WHERE state_key = 'tickets' LIMIT 1");
+  if (!ticketsRow && fs.existsSync(STORE_TICKETS)) {
+    const fileTickets = loadJson(STORE_TICKETS, DEFAULT_TICKETS);
+    await pool.query(
+      "INSERT INTO app_state (state_key, state_value) VALUES ('tickets', ?) ON DUPLICATE KEY UPDATE state_value = VALUES(state_value)",
+      [JSON.stringify(fileTickets)]
+    );
+  }
+
+  const [[panelsRow]] = await pool.query("SELECT state_key FROM app_state WHERE state_key = 'panels' LIMIT 1");
+  if (!panelsRow && fs.existsSync(STORE_PANELS)) {
+    const filePanels = loadJson(STORE_PANELS, DEFAULT_PANELS);
+    await pool.query(
+      "INSERT INTO app_state (state_key, state_value) VALUES ('panels', ?) ON DUPLICATE KEY UPDATE state_value = VALUES(state_value)",
+      [JSON.stringify(filePanels)]
+    );
+  }
+
+  migrationDone = true;
+}
+
+async function loadStateFromDb(key, fallback) {
+  await migrateJsonToDatabaseIfNeeded();
+  const ready = await ensureDatabase();
+  if (!ready) return fallback;
+
+  const [rows] = await pool.query("SELECT state_value FROM app_state WHERE state_key = ? LIMIT 1", [key]);
+  if (!rows.length) return fallback;
+
+  try {
+    return JSON.parse(rows[0].state_value);
+  } catch {
+    return fallback;
+  }
+}
+
+async function saveStateToDb(key, data) {
+  await migrateJsonToDatabaseIfNeeded();
+  const ready = await ensureDatabase();
+  if (!ready) return false;
+
+  await pool.query(
+    "INSERT INTO app_state (state_key, state_value) VALUES (?, ?) ON DUPLICATE KEY UPDATE state_value = VALUES(state_value)",
+    [key, JSON.stringify(data)]
+  );
+  return true;
+}
+
+async function loadTickets() {
+  const ready = await ensureDatabase();
+  if (!ready) return loadJson(STORE_TICKETS, DEFAULT_TICKETS);
+  return loadStateFromDb("tickets", DEFAULT_TICKETS);
+}
+
+async function saveTickets(data) {
+  const ok = await saveStateToDb("tickets", data);
+  if (!ok) saveJson(STORE_TICKETS, data);
+}
+
+async function loadPanels() {
+  const ready = await ensureDatabase();
+  if (!ready) return loadJson(STORE_PANELS, DEFAULT_PANELS);
+  return loadStateFromDb("panels", DEFAULT_PANELS);
+}
+
+async function savePanels(data) {
+  const ok = await saveStateToDb("panels", data);
+  if (!ok) saveJson(STORE_PANELS, data);
+}
+
+async function nextTicketId(store = null) {
+  if (store) {
+    store.nextTicketId = (store.nextTicketId || 1000) + 1;
+    return store.nextTicketId;
+  }
+
+  const loadedStore = await loadTickets();
+  loadedStore.nextTicketId = (loadedStore.nextTicketId || 1000) + 1;
+  await saveTickets(loadedStore);
+  return loadedStore.nextTicketId;
 }
 
 module.exports = { loadTickets, saveTickets, loadPanels, savePanels, nextTicketId };

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "discord.js": "^14.14.1"
+    "discord.js": "^14.14.1",
+    "dotenv": "^16.4.5",
+    "mysql2": "^3.11.3"
   }
 }

--- a/panels/panelHandler.js
+++ b/panels/panelHandler.js
@@ -56,7 +56,7 @@ async function findExistingPanelMessage(channel, panelConfig) {
 }
 
 module.exports.upsertPanels = async (client, config) => {
-  const store = loadPanels();
+  const store = await loadPanels();
   const panels = config.panels || {};
 
   for (const key of Object.keys(panels)) {
@@ -92,14 +92,14 @@ module.exports.upsertPanels = async (client, config) => {
     if (existing) {
       await existing.edit({ embeds: [embed], components: [row] }).catch(() => null);
       store.panels[key] = { channelId: p.channelId, messageId: existing.id };
-      savePanels(store);
+      await savePanels(store);
       continue;
     }
 
     const sent = await channel.send({ embeds: [embed], components: [row] }).catch(() => null);
     if (sent) {
       store.panels[key] = { channelId: p.channelId, messageId: sent.id };
-      savePanels(store);
+      await savePanels(store);
     }
   }
 };
@@ -108,7 +108,7 @@ module.exports.upsertPermanentMessage = async (client, config) => {
   const permanent = config.permanentSupportMessage;
   if (!permanent?.channelId) return;
 
-  const store = loadPanels();
+  const store = await loadPanels();
   store.permanentMessages = store.permanentMessages || {};
 
   const channel = await client.channels.fetch(permanent.channelId).catch(() => null);
@@ -150,7 +150,7 @@ module.exports.upsertPermanentMessage = async (client, config) => {
   if (fallbackExisting) {
     await fallbackExisting.edit(messagePayload).catch(() => null);
     store.permanentMessages[key] = { channelId: permanent.channelId, messageId: fallbackExisting.id };
-    savePanels(store);
+    await savePanels(store);
     return;
   }
 
@@ -158,5 +158,5 @@ module.exports.upsertPermanentMessage = async (client, config) => {
   if (!sent) return;
 
   store.permanentMessages[key] = { channelId: permanent.channelId, messageId: sent.id };
-  savePanels(store);
+  await savePanels(store);
 };


### PR DESCRIPTION
### Motivation
- Make database initialization more robust for hosts that either already created the DB or need the bot to create it, and provide clear instructions for manual setup.

### Description
- Updated `ensureDatabase` in `handlers/helpers.js` to first attempt connecting to the configured database and create the `app_state` table, and only if the error is `ER_BAD_DB_ERROR` perform `CREATE DATABASE IF NOT EXISTS` and retry table creation.
- Preserved automatic migration: `migrateJsonToDatabaseIfNeeded` still imports `storage/tickets.json` and `storage/panels.json` into `app_state` when needed.
- Clarified `README.txt` to state that the bot auto-creates the `app_state` table and added an optional phpMyAdmin/SQL snippet to manually create `bot_tickets_live` and `app_state` if desired.

### Testing
- Ran `node --check handlers/helpers.js` and it succeeded.
- Ran `node --check index.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f79fcda4883328f8af0434b1c86e7)